### PR TITLE
Remove ServiceConfiguration.ConfigError() arg

### DIFF
--- a/lib/ok_client.js
+++ b/lib/ok_client.js
@@ -9,7 +9,7 @@ OK.requestCredential = function (options, credentialRequestCompleteCallback) {
 
     var config = ServiceConfiguration.configurations.findOne({service: 'ok'});
     if (!config) {
-        credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError("Service not configured"));
+        credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError());
         return;
     }
 


### PR DESCRIPTION
Hi,
Method ServiceConfiguration.ConfigError() takes one arg serviceName for string "Service `serviceName` not configured" or nothing if we want pure string "Service not configured"
[link to method](https://github.com/meteor/meteor/blob/832e6fe44f3635cae060415d6150c0105f2bf0f6/packages/service-configuration/service_configuration_common.js)
